### PR TITLE
Scrolling bug fix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,14 @@
-import { useEffect, useRef, useState } from 'react';
-// import "./styles/slick.css";
-// import "./styles/slick-theme.css";
-import styles from './App.module.css';
-import Header from './components/Header/Header';
-import AboutMe from './views/AboutMe/AboutMe';
-import Projects from './views/Projects/Projects';
-import TAB_OPTIONS from './enums/tabOptions';
-import Welcome from './views/Welcome/Welcome';
-import ViewContainer from './components/ViewContainer/ViewContainer';
-import WorkHistory from './views/WorkHistory/WorkHistory';
-
+import { useEffect, useRef, useState } from "react";
+import Header from "./components/Header/Header";
+import AboutMe from "./views/AboutMe/AboutMe";
+import Projects from "./views/Projects/Projects";
+import TAB_OPTIONS from "./enums/tabOptions";
+import Welcome from "./views/Welcome/Welcome";
+import ViewContainer from "./components/ViewContainer/ViewContainer";
+import WorkHistory from "./views/WorkHistory/WorkHistory";
 
 export default function App() {
-
-  const [activeTab, setActiveTab] = useState(TAB_OPTIONS.WELCOME)
+  const [activeTab, setActiveTab] = useState(TAB_OPTIONS.WELCOME);
 
   const welcomeRef = useRef();
   const aboutRef = useRef();
@@ -23,90 +18,95 @@ export default function App() {
   const TAB_REF_LINK = {
     WELCOME: welcomeRef,
     ABOUT: aboutRef,
-    PROJECTS: projectRef, 
-    HISTORY: historyRef
-  }
+    PROJECTS: projectRef,
+    HISTORY: historyRef,
+  };
 
   useEffect(() => {
     function updateActiveTab() {
       let allRefs = [welcomeRef, aboutRef, projectRef, historyRef];
-      let scrollY = window.scrollY;
+      let scrollY = Math.trunc(window.scrollY);
 
       allRefs.forEach((elmRef, index) => {
         const sectionHeight = elmRef.current.offsetHeight;
-        const sectionTop = (elmRef.current.getBoundingClientRect().top + window.scrollY) - 75;
-      if (
-        scrollY === sectionTop &&
-        scrollY <= sectionTop + sectionHeight
-      ){
-        const activeElm = Object.keys(TAB_OPTIONS)[index];
-        setActiveTab(TAB_OPTIONS[activeElm])
-      } else return;
-    })
+        const sectionTop = Math.trunc(
+          elmRef.current.getBoundingClientRect().top + window.scrollY - 75
+        );
 
+        if (
+          (scrollY === sectionTop || scrollY === sectionTop + 1) &&
+          scrollY <= sectionTop + sectionHeight
+        ) {
+          const activeElm = Object.keys(TAB_OPTIONS)[index];
+          setActiveTab(TAB_OPTIONS[activeElm]);
+        } else return;
+      });
     }
     window.addEventListener("scrollend", updateActiveTab);
 
-    return () => (window.removeEventListener("scrollend", updateActiveTab)
-  );
-
+    return () => window.removeEventListener("scrollend", updateActiveTab);
   }, []);
 
   function handleScrollChange(e, id) {
     e.preventDefault();
-    if(id === "ABOUT") {
-      aboutRef.current.scrollIntoView({ block: 'end', behavior: 'smooth' });
+    if (id === "ABOUT") {
+      aboutRef.current.scrollIntoView({ block: "end", behavior: "smooth" });
       setActiveTab(TAB_OPTIONS.ABOUT);
-    } else if (id === "PROJECTS"){
-      projectRef.current.scrollIntoView({block: 'end',  behavior: 'smooth' });
+    } else if (id === "PROJECTS") {
+      projectRef.current.scrollIntoView({ block: "end", behavior: "smooth" });
       setActiveTab(TAB_OPTIONS.PROJECTS);
-    }else if (id === "WELCOME"){
-      welcomeRef.current.scrollIntoView({ block: 'end', behavior: 'smooth' });
+    } else if (id === "WELCOME") {
+      welcomeRef.current.scrollIntoView({ block: "end", behavior: "smooth" });
       setActiveTab(TAB_OPTIONS.WELCOME);
-    }else if (id === "HISTORY"){
-      historyRef.current.scrollIntoView({ block: 'end', behavior: 'smooth' });
+    } else if (id === "HISTORY") {
+      historyRef.current.scrollIntoView({ block: "end", behavior: "smooth" });
       setActiveTab(TAB_OPTIONS.HISTORY);
     }
   }
 
   const changeActiveTab = (id) => {
     setActiveTab(id);
-  }
+  };
 
- return (
-  <>
-    <Header handleScrollChange={handleScrollChange} activeTab={activeTab}></Header>
+  return (
+    <>
+      <Header
+        handleScrollChange={handleScrollChange}
+        activeTab={activeTab}
+      ></Header>
 
-    <ViewContainer 
-      key={TAB_OPTIONS.WELCOME} 
-      changeActiveTab={changeActiveTab} 
-      id={TAB_OPTIONS.WELCOME} 
-      ref={welcomeRef}>
-        <Welcome/>
-    </ViewContainer>
-    <ViewContainer 
-      key={TAB_OPTIONS.ABOUT} 
-      changeActiveTab={changeActiveTab} 
-      id={TAB_OPTIONS.ABOUT} 
-      ref={aboutRef}>
+      <ViewContainer
+        key={TAB_OPTIONS.WELCOME}
+        changeActiveTab={changeActiveTab}
+        id={TAB_OPTIONS.WELCOME}
+        ref={welcomeRef}
+      >
+        <Welcome />
+      </ViewContainer>
+      <ViewContainer
+        key={TAB_OPTIONS.ABOUT}
+        changeActiveTab={changeActiveTab}
+        id={TAB_OPTIONS.ABOUT}
+        ref={aboutRef}
+      >
         <AboutMe />
-    </ViewContainer>
-    <ViewContainer 
-      key={TAB_OPTIONS.PROJECTS} 
-      changeActiveTab={changeActiveTab} 
-      id={TAB_OPTIONS.PROJECTS} 
-      ref={projectRef}>
-        <Projects/>
-    </ViewContainer>
-    <ViewContainer 
-      key={TAB_OPTIONS.HISTORY} 
-      changeActiveTab={changeActiveTab} 
-      id={TAB_OPTIONS.HISTORY} 
-      ref={historyRef}>
-        <WorkHistory/>
-    </ViewContainer>
-
-  </>
- )
+      </ViewContainer>
+      <ViewContainer
+        key={TAB_OPTIONS.PROJECTS}
+        changeActiveTab={changeActiveTab}
+        id={TAB_OPTIONS.PROJECTS}
+        ref={projectRef}
+      >
+        <Projects />
+      </ViewContainer>
+      <ViewContainer
+        key={TAB_OPTIONS.HISTORY}
+        changeActiveTab={changeActiveTab}
+        id={TAB_OPTIONS.HISTORY}
+        ref={historyRef}
+      >
+        <WorkHistory />
+      </ViewContainer>
+    </>
+  );
 }
-

--- a/src/components/MainDetailsCard/MainDetailsCard.jsx
+++ b/src/components/MainDetailsCard/MainDetailsCard.jsx
@@ -18,7 +18,7 @@ export default function MainDetailsCard({ mainDetails }) {
           }
 
           return (
-            <div className={styles.single_item}>
+            <div className={styles.single_item} key={key}>
               <Title variant={3}>{MAIN_DETAILS_HEADINGS[key]}: </Title>
               <p>{val}</p>
             </div>

--- a/src/components/MoreExperienceCard/MoreExperienceCard.jsx
+++ b/src/components/MoreExperienceCard/MoreExperienceCard.jsx
@@ -8,8 +8,8 @@ export default function MoreExperienceCard({ otherExperience }) {
       <section>
         <Title variant="3">More Experience</Title>
         <ul>
-          {otherExperience.map((detail) => (
-            <li>{detail}</li>
+          {otherExperience.map((detail, i) => (
+            <li key={i}>{detail}</li>
           ))}
         </ul>
       </section>


### PR DESCRIPTION
##Description

Issue presented that the header tabs were not correctly being updated when the user scrolled to a different section. The issue was the exact comparison with the view values that would not directly match. 
The fix is a bit hackish, and deserves a second pass. I ended up truncating to the integer only and that fixed 3/4 of the views. However, the initial Welcome view was still off my a full integer. To account for that, I added a second conditional to factor in that case as well. 

In addition, cleared some console errors about not having keys on iterated components. 